### PR TITLE
Fix map page asset paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
   />
 
   <!-- Your custom CSS (styles.css) -->
-  <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="static/styles.css" />
 
   <!-- Leaflet JS -->
   <script
@@ -27,7 +27,7 @@
   ></script>
 
   <!-- Minimal map script -->
-  <script src="script.js" defer></script>
+  <script src="static/script.js" defer></script>
 </head>
 <body>
   <div id="map"></div>


### PR DESCRIPTION
## Summary
- reference CSS and JS from the `static` folder in `index.html`

## Testing
- `node static/script.js` *(fails: `L` is not defined)*